### PR TITLE
Removed duplicate install command

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -22,7 +22,7 @@ trigger-ansible-dependencies() {
       echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu $OS_ID main" > /etc/apt/sources.list.d/ansible.list
       apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
       apt update
-      apt-get -qq -y --no-install-recommends install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install ansible
+      apt-get -qq -y --no-install-recommends install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ansible
       ;;
 
     ubuntu)
@@ -33,7 +33,7 @@ trigger-ansible-dependencies() {
 
       apt update
       add-apt-repository --yes --update ppa:ansible/ansible
-      apt-get -qq -y --no-install-recommends install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install ansible
+      apt-get -qq -y --no-install-recommends install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ansible
       ;;
 
   esac


### PR DESCRIPTION
The install script mentions the word `install` twice so it breaks the ansible installation
```
Reading package lists... Done
+ apt-get -qq -y --no-install-recommends install -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install ansible
E: Unable to locate package install
```